### PR TITLE
Laravel 8 upgrade but Laravel <= 6 dropped

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 7.4, 7.3 ]
-        laravel: [ 8.*, 7.* ]
+        php: [ 7.3, 7.4 ]
+        laravel: [ '^6.10', '^7.0', '^7.8' ]
         dependency-version: [prefer-lowest, prefer-stable]
-        include:
-          - laravel: 7.*
-            testbench: 5.*
-          - laravel: 8.*
-            testbench: 6.*
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
     steps:
       - name: Update apt
@@ -37,7 +32,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.composer/cache/files
-          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+          key: laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -51,8 +46,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+          composer require "illuminate/support:${{ matrix.laravel }}" "illuminate/http:${{ matrix.laravel }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }}  --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: vendor/bin/phpunit --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test
+name: run-tests
 
 on:
   push:
@@ -9,26 +9,41 @@ on:
       - 'master'
 
 jobs:
-  build:
-    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
+  test:
     runs-on: ubuntu-latest
+
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        php: [ '7.2', '7.3', '7.4' ]
-        laravel: [ '5.5.*', '5.6.*', '5.7.*', '5.8.*', '^6.0', '^7.0' ]
+        php: [ 7.4, 7.3 ]
+        laravel: [ 8.*, 7.* ]
+        dependency-version: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: 7.*
+            testbench: 5.*
+          - laravel: 8.*
+            testbench: 6.*
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Update apt
+        run: sudo apt-get update --fix-missing
 
-      - uses: actions/cache@v1
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
         with:
           path: ~/.composer/cache/files
-          key: laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
-      - uses: shivammathur/setup-php@v1
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
 
       - name: Validate composer.json
@@ -36,8 +51,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/support:${{ matrix.laravel }}" "illuminate/http:${{ matrix.laravel }}" --no-interaction --no-update
-          composer update --prefer-dist --no-interaction --no-suggest
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
-      - name: Run test
-        run: ./vendor/bin/phpunit --verbose
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This package helps integrate a Laravel application with chunk uploader libraries
 [DropzoneJS](https://www.dropzonejs.com/) and
 [jQuery-File-Upload from blueimp](https://blueimp.github.io/jQuery-File-Upload/).
 
-Uploading a large file in chunks can help reduce risks. 
+Uploading a large file in chunks can help reduce risks.
 
 - PHP from 5.3.4 limits the number of concurrent uploads and by uploading a file in one request can limit the
 availability of a service. ([max_file_uploads][php-max-file-uploads])
@@ -47,7 +47,7 @@ project at the moment is [tus](https://tus.io/).
     - [NOP identifier](#nop-identifier)
 - [Contribution](#contribution)
 - [License](#license)
-    
+
 ## Installation
 
 You can easily install this package using Composer, by running the following command:
@@ -60,8 +60,8 @@ composer require coding-socks/laravel-upload-handler
 
 This package has the following requirements:
 
-- PHP 7.1 or higher
-- Laravel 5.5 or higher
+- PHP 7.3 or higher
+- Laravel 7 or higher
 
 ## Usage
 
@@ -115,7 +115,7 @@ the disk and the path of the uploaded file.
 [Registering Events & Listeners from Laravel](https://laravel.com/docs/5.8/events#registering-events-and-listeners)
 
 You can also add a `Closure` as the second parameter of the `handle` method to add an inline listener. The listener
-is called with the disk and the path of the uploaded file. 
+is called with the disk and the path of the uploaded file.
 
 ```php
 $handler->handle($request, function ($disk, $path) {

--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ composer require coding-socks/laravel-upload-handler
 
 This package has the following requirements:
 
-- PHP 7.3 or higher
-- Laravel 7 or higher
+- PHP `^7.3`
+- Laravel `^6.10 || ^7.0 || ^8.0`
+
+[Caret Version Range (^)](https://getcomposer.org/doc/articles/versions.md#caret-version-range-)
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "illuminate/support": "^5.5 || ^6.0 || ^7.0",
-        "illuminate/http": "^5.5 || ^6.0 || ^7.0"
+        "php": "^7.3",
+        "illuminate/support": "^7.0 || ^8.0",
+        "illuminate/http": "^7.0 || ^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.5 || ^4.0 || ^5.0",
-        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0",
-        "mockery/mockery": "^1.0"
+        "orchestra/testbench": "^5.0 || ^6.0",
+        "phpunit/phpunit": "^9.1",
+        "mockery/mockery": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
     ],
     "require": {
         "php": "^7.3",
-        "illuminate/support": "^7.0 || ^8.0",
-        "illuminate/http": "^7.0 || ^8.0"
+        "illuminate/support": "^6.10 || ^7.0 || ^8.0",
+        "illuminate/http": "^6.10 || ^7.0 || ^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0 || ^6.0",
-        "phpunit/phpunit": "^9.1",
+        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0",
+        "phpunit/phpunit": "^9.3",
         "mockery/mockery": "^1.3"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,34 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         beStrictAboutOutputDuringTests="true"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         failOnRisky="true"
-         failOnWarning="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="Laravel Upload Handler Test Suite">
-            <directory>./tests</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         verbose="true">
     <coverage>
         <include>
             <directory suffix=".php">src/</directory>
         </include>
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
     </coverage>
     <testsuites>
         <testsuite name="Laravel Upload Handler Test Suite">
@@ -11,9 +18,7 @@
         </testsuite>
     </testsuites>
     <logging>
-      <log type="tap" target="build/report.tap"/>
-      <log type="junit" target="build/report.junit.xml"/>
-      <log type="coverage-text" target="build/coverage.txt"/>
-      <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <junit outputFile="build/report.junit.xml"/>
+        <text outputFile="build/coverage.txt"/>
     </logging>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,4 +10,10 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <logging>
+      <log type="tap" target="build/report.tap"/>
+      <log type="junit" target="build/report.junit.xml"/>
+      <log type="coverage-text" target="build/coverage.txt"/>
+      <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
 </phpunit>

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -31,7 +31,7 @@ class IdentityManager extends Manager
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['upload-handler.identifier'];
+        return $this->container['config']['upload-handler.identifier'];
     }
 
     /**
@@ -43,6 +43,6 @@ class IdentityManager extends Manager
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['upload-handler.identifier'] = $name;
+        $this->container['config']['upload-handler.identifier'] = $name;
     }
 }

--- a/src/UploadManager.php
+++ b/src/UploadManager.php
@@ -16,25 +16,25 @@ class UploadManager extends Manager
 {
     public function createMonolithDriver()
     {
-        return new MonolithBaseHandler($this->app['config']['upload-handler.monolith']);
+        return new MonolithBaseHandler($this->container['config']['upload-handler.monolith']);
     }
 
     public function createBlueimpDriver()
     {
         /** @var \Illuminate\Support\Manager $identityManager */
-        $identityManager = $this->app['upload-handler.identity-manager'];
+        $identityManager = $this->container['upload-handler.identity-manager'];
 
-        return new BlueimpBaseHandler($this->app['config']['upload-handler.blueimp'], $identityManager->driver());
+        return new BlueimpBaseHandler($this->container['config']['upload-handler.blueimp'], $identityManager->driver());
     }
 
     public function createDropzoneDriver()
     {
-        return new DropzoneBaseHandler($this->app['config']['upload-handler.dropzone']);
+        return new DropzoneBaseHandler($this->container['config']['upload-handler.dropzone']);
     }
 
     public function createFlowJsDriver()
     {
-        return new FlowJsHandler($this->app['config']['upload-handler.resumable-js'], $this->identityManager()->driver());
+        return new FlowJsHandler($this->container['config']['upload-handler.resumable-js'], $this->identityManager()->driver());
     }
 
     public function createNgFileUploadDriver()
@@ -49,12 +49,12 @@ class UploadManager extends Manager
 
     public function createResumableJsDriver()
     {
-        return new ResumableJsBaseHandler($this->app['config']['upload-handler.resumable-js'], $this->identityManager()->driver());
+        return new ResumableJsBaseHandler($this->container['config']['upload-handler.resumable-js'], $this->identityManager()->driver());
     }
 
     public function createSimpleUploaderJsDriver()
     {
-        return new SimpleUploaderJsHandler($this->app['config']['upload-handler.simple-uploader-js'], $this->identityManager()->driver());
+        return new SimpleUploaderJsHandler($this->container['config']['upload-handler.simple-uploader-js'], $this->identityManager()->driver());
     }
 
     /**
@@ -62,7 +62,7 @@ class UploadManager extends Manager
      */
     protected function identityManager()
     {
-        return $this->app['upload-handler.identity-manager'];
+        return $this->container['upload-handler.identity-manager'];
     }
 
     /**
@@ -72,7 +72,7 @@ class UploadManager extends Manager
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['upload-handler.handler'];
+        return $this->container['config']['upload-handler.handler'];
     }
 
     /**
@@ -84,6 +84,6 @@ class UploadManager extends Manager
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['upload-handler.handler'] = $name;
+        $this->container['config']['upload-handler.handler'] = $name;
     }
 }

--- a/tests/Driver/BlueimpUploadHandlerTest.php
+++ b/tests/Driver/BlueimpUploadHandlerTest.php
@@ -28,10 +28,10 @@ class BlueimpUploadHandlerTest extends TestCase
     {
         parent::setUp();
 
-        $this->app->make('config')->set('upload-handler.identifier', 'nop');
-        $this->app->make('config')->set('upload-handler.handler', 'blueimp');
-        $this->app->make('config')->set('upload-handler.sweep', false);
-        $this->handler = $this->app->make(UploadHandler::class);
+        config()->set('upload-handler.identifier', 'nop');
+        config()->set('upload-handler.handler', 'blueimp');
+        config()->set('upload-handler.sweep', false);
+        $this->handler = app()->make(UploadHandler::class);
 
         Storage::fake('local');
         Event::fake();
@@ -39,7 +39,7 @@ class BlueimpUploadHandlerTest extends TestCase
 
     public function testDriverInstance()
     {
-        $manager = $this->app->make('upload-handler.upload-manager');
+        $manager = app()->make('upload-handler.upload-manager');
 
         $this->assertInstanceOf(BlueimpBaseHandler::class, $manager->driver());
     }
@@ -120,7 +120,8 @@ class BlueimpUploadHandlerTest extends TestCase
 
     public function testUploadWhenFileParameterIsInvalid()
     {
-        $file = Mockery::mock(UploadedFile::class)->makePartial();
+        $file = Mockery::mock(UploadedFile::class)
+            ->makePartial();
         $file->shouldReceive('isValid')
             ->andReturn(false);
 

--- a/tests/Driver/DropzoneUploadHandlerTest.php
+++ b/tests/Driver/DropzoneUploadHandlerTest.php
@@ -26,9 +26,9 @@ class DropzoneUploadHandlerTest extends TestCase
     {
         parent::setUp();
 
-        $this->app->make('config')->set('upload-handler.handler', 'dropzone');
-        $this->app->make('config')->set('upload-handler.sweep', false);
-        $this->handler = $this->app->make(UploadHandler::class);
+        config()->set('upload-handler.handler', 'dropzone');
+        config()->set('upload-handler.sweep', false);
+        $this->handler = app()->make(UploadHandler::class);
 
         Storage::fake('local');
         Event::fake();
@@ -36,7 +36,7 @@ class DropzoneUploadHandlerTest extends TestCase
 
     public function testDriverInstance()
     {
-        $manager = $this->app->make('upload-handler.upload-manager');
+        $manager = app()->make('upload-handler.upload-manager');
 
         $this->assertInstanceOf(DropzoneBaseHandler::class, $manager->driver());
     }

--- a/tests/Driver/FlowJsUploadHandlerTest.php
+++ b/tests/Driver/FlowJsUploadHandlerTest.php
@@ -28,10 +28,10 @@ class FlowJsUploadHandlerTest extends TestCase
     {
         parent::setUp();
 
-        $this->app->make('config')->set('upload-handler.identifier', 'nop');
-        $this->app->make('config')->set('upload-handler.handler', 'flow-js');
-        $this->app->make('config')->set('upload-handler.sweep', false);
-        $this->handler = $this->app->make(UploadHandler::class);
+        config()->set('upload-handler.identifier', 'nop');
+        config()->set('upload-handler.handler', 'flow-js');
+        config()->set('upload-handler.sweep', false);
+        $this->handler = app()->make(UploadHandler::class);
 
         Storage::fake('local');
         Event::fake();
@@ -39,7 +39,7 @@ class FlowJsUploadHandlerTest extends TestCase
 
     public function testDriverInstance()
     {
-        $manager = $this->app->make('upload-handler.upload-manager');
+        $manager = app()->make('upload-handler.upload-manager');
 
         $this->assertInstanceOf(FlowJsHandler::class, $manager->driver());
     }

--- a/tests/Driver/MonolithUploadHandlerTest.php
+++ b/tests/Driver/MonolithUploadHandlerTest.php
@@ -28,8 +28,8 @@ class MonolithUploadHandlerTest extends TestCase
     {
         parent::setUp();
 
-        $this->app->make('config')->set('upload-handler.handler', 'monolith');
-        $this->handler = $this->app->make(UploadHandler::class);
+        config()->set('upload-handler.handler', 'monolith');
+        $this->handler = app()->make(UploadHandler::class);
 
         Storage::fake('local');
         Event::fake();
@@ -37,7 +37,7 @@ class MonolithUploadHandlerTest extends TestCase
 
     public function testDriverInstance()
     {
-        $manager = $this->app->make('upload-handler.upload-manager');
+        $manager = app()->make('upload-handler.upload-manager');
 
         $this->assertInstanceOf(MonolithBaseHandler::class, $manager->driver());
     }

--- a/tests/Driver/NgFileUploadHandlerTest.php
+++ b/tests/Driver/NgFileUploadHandlerTest.php
@@ -27,10 +27,10 @@ class NgFileUploadHandlerTest extends TestCase
     {
         parent::setUp();
 
-        $this->app->make('config')->set('upload-handler.identifier', 'nop');
-        $this->app->make('config')->set('upload-handler.handler', 'ng-file-upload');
-        $this->app->make('config')->set('upload-handler.sweep', false);
-        $this->handler = $this->app->make(UploadHandler::class);
+        config()->set('upload-handler.identifier', 'nop');
+        config()->set('upload-handler.handler', 'ng-file-upload');
+        config()->set('upload-handler.sweep', false);
+        $this->handler = app()->make(UploadHandler::class);
 
         Storage::fake('local');
         Event::fake();
@@ -38,7 +38,7 @@ class NgFileUploadHandlerTest extends TestCase
 
     public function testDriverInstance()
     {
-        $manager = $this->app->make('upload-handler.upload-manager');
+        $manager = app()->make('upload-handler.upload-manager');
 
         $this->assertInstanceOf(NgFileBaseHandler::class, $manager->driver());
     }

--- a/tests/Driver/PluploadUploadHandlerTest.php
+++ b/tests/Driver/PluploadUploadHandlerTest.php
@@ -27,10 +27,10 @@ class PluploadUploadHandlerTest extends TestCase
     {
         parent::setUp();
 
-        $this->app->make('config')->set('upload-handler.identifier', 'nop');
-        $this->app->make('config')->set('upload-handler.handler', 'plupload');
-        $this->app->make('config')->set('upload-handler.sweep', false);
-        $this->handler = $this->app->make(UploadHandler::class);
+        config()->set('upload-handler.identifier', 'nop');
+        config()->set('upload-handler.handler', 'plupload');
+        config()->set('upload-handler.sweep', false);
+        $this->handler = app()->make(UploadHandler::class);
 
         Storage::fake('local');
         Event::fake();
@@ -38,7 +38,7 @@ class PluploadUploadHandlerTest extends TestCase
 
     public function testDriverInstance()
     {
-        $manager = $this->app->make('upload-handler.upload-manager');
+        $manager = app()->make('upload-handler.upload-manager');
 
         $this->assertInstanceOf(PluploadBaseHandler::class, $manager->driver());
     }

--- a/tests/Driver/ResumableJsUploadHandlerTest.php
+++ b/tests/Driver/ResumableJsUploadHandlerTest.php
@@ -28,10 +28,10 @@ class ResumableJsUploadHandlerTest extends TestCase
     {
         parent::setUp();
 
-        $this->app->make('config')->set('upload-handler.identifier', 'nop');
-        $this->app->make('config')->set('upload-handler.handler', 'resumable-js');
-        $this->app->make('config')->set('upload-handler.sweep', false);
-        $this->handler = $this->app->make(UploadHandler::class);
+        config()->set('upload-handler.identifier', 'nop');
+        config()->set('upload-handler.handler', 'resumable-js');
+        config()->set('upload-handler.sweep', false);
+        $this->handler = app()->make(UploadHandler::class);
 
         Storage::fake('local');
         Event::fake();
@@ -39,7 +39,7 @@ class ResumableJsUploadHandlerTest extends TestCase
 
     public function testDriverInstance()
     {
-        $manager = $this->app->make('upload-handler.upload-manager');
+        $manager = app()->make('upload-handler.upload-manager');
 
         $this->assertInstanceOf(ResumableJsBaseHandler::class, $manager->driver());
     }

--- a/tests/Driver/SimpleUploaderUploadHandlerTest.php
+++ b/tests/Driver/SimpleUploaderUploadHandlerTest.php
@@ -28,10 +28,10 @@ class SimpleUploaderUploadHandlerTest extends TestCase
     {
         parent::setUp();
 
-        $this->app->make('config')->set('upload-handler.identifier', 'nop');
-        $this->app->make('config')->set('upload-handler.handler', 'simple-uploader-js');
-        $this->app->make('config')->set('upload-handler.sweep', false);
-        $this->handler = $this->app->make(UploadHandler::class);
+        config()->set('upload-handler.identifier', 'nop');
+        config()->set('upload-handler.handler', 'simple-uploader-js');
+        config()->set('upload-handler.sweep', false);
+        $this->handler = app()->make(UploadHandler::class);
 
         Storage::fake('local');
         Event::fake();
@@ -39,7 +39,7 @@ class SimpleUploaderUploadHandlerTest extends TestCase
 
     public function testDriverInstance()
     {
-        $manager = $this->app->make('upload-handler.upload-manager');
+        $manager = app()->make('upload-handler.upload-manager');
 
         $this->assertInstanceOf(SimpleUploaderJsHandler::class, $manager->driver());
     }


### PR DESCRIPTION
Hello,

I worked to make the package compatible with Laravel 8, I removed support for version <=6 and php <=7.2 for convenience and because I did not need them.

