### PR TITLE
Laravel 10 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 7.3, 7.4, 8.0 ]
-        laravel: [ '^6.10', '^8.0', '^9.0' ]
+        php: [ 8.0, 8.1, 8.2 ]
+        laravel: [ '^9.0', '^10.0' ]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
-          - php: 7.4
-            laravel: '^9.0'
-          - php: 7.3
-            laravel: '^9.0'
+          - php: 8.0
+            laravel: '^10.0'
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
@@ -31,10 +29,10 @@ jobs:
         run: sudo apt-get update --fix-missing
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache/files
           key: laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
-        "illuminate/support": "^6.10 || ^8.0 || ^9.0",
-        "illuminate/http": "^6.10 || ^8.0 || ^9.0"
+        "php": "^8.0",
+        "illuminate/support": "^9.0 || ^10.0",
+        "illuminate/http": "^9.0 || ^10.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.18 || ^6.24 || ^7.3",
+        "orchestra/testbench": "^7.3 || ^8.0",
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {


### PR DESCRIPTION
This PR adds Laravel ^10.0 support. Additionally, it removes Laravel ^6.10 and ^8.0 support.